### PR TITLE
Add rrdtool to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 modoboa>=1.4.0
 lxml
+python-rrdtool


### PR DESCRIPTION
At least for me it was not obvious that I was missing the python module for rrdtool.