### PR TITLE
Add preliminary support for Rmilter/Rspamd

### DIFF
--- a/modoboa_stats/forms.py
+++ b/modoboa_stats/forms.py
@@ -28,3 +28,12 @@ class ParametersForm(param_forms.AdminParametersForm):
             "Path to directory where RRD files are stored"),
         widget=forms.TextInput(attrs={"class": "form-control"})
     )
+
+    spam_detection = forms.ChoiceField(
+        label=ugettext_lazy("Spam detection software"),
+        choices=[("amavis", "Amavis"),
+                 ("rmilter", "Rmilter/Rspamd")],
+        initial="amavis",
+        help_text=ugettext_lazy("Anti-spam software used"),
+        widget=forms.Select(attrs={"class": "form-control"})
+    )


### PR DESCRIPTION
As looks only on a single line, this can't detect virus mails when Rmilter support is enabled (and Rmilter is used with Rspamd, as is recommended). It is likely that Rmilter will become obsolete in the near future as support for the milter protocol will be added to Rspamd.