### PR TITLE
prepare for release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,9 @@ before_install:
   - pip install -e git+https://github.com/modoboa/modoboa.git#egg=modoboa
 
 install:
-  - pip install -q -r requirements.txt
-  - pip install -q -r test-requirements.txt
-  - python setup.py -q develop
+  - pip install -r requirements.txt
+  - pip install -r test-requirements.txt
+  - python setup.py develop
 
 script:
   - cd test_project

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,32 +10,28 @@ env:
     - PYTHONWARNINGS="default,ignore::PendingDeprecationWarning,ignore::ResourceWarning"
   matrix:
     - DB="POSTGRESQL"
+    - DB="MYSQL"
 
 sudo: false
 
+cache: pip
+
 addons:
+  postgresql: "9.3"
+  mysql: "5.5"
   apt:
     packages:
       - librrd-dev
       - rrdtool
 
-cache: pip
-
-services:
-  - postgres
-
 before_install:
   - pip install codecov
-  - if [[ $DB = "POSTGRESQL" ]]; then pip install -q psycopg2; fi
-  - pip install -e git+https://github.com/modoboa/modoboa#egg=modoboa
+  - pip install -e git+https://github.com/modoboa/modoboa.git#egg=modoboa
 
 install:
   - pip install -q -r requirements.txt
   - pip install -q -r test-requirements.txt
   - python setup.py -q develop
-
-before_script:
-  - if [[ $DB = "POSTGRESQL" ]]; then psql -c "CREATE DATABASE modoboa_test;" -U postgres; fi
 
 script:
   - cd test_project
@@ -55,6 +51,8 @@ deploy:
   password:
     secure: WHShe/aXEoTkx3J+nL0P28/BA+LZfZvj6bdNwZCVlAOPegl/h4JQx3gymmX3uygHS2LRlKy7YRt3BTVlSn7/T2R/rD/jbOkHhl27cCPbhO/cS2BWWorYzJOVjqyHOEbD1VXaAQxE4UJ2/EDw1wqbvgkPaRZX+VQiyqx1nGH044I=
   skip_cleanup: true
+  distributions: "sdist bdist_wheel"
   on:
     tags: true
-    python: '3.6'
+    python: "3.6"
+    condition: $DB = POSTGRESQL

--- a/modoboa_stats/__init__.py
+++ b/modoboa_stats/__init__.py
@@ -1,3 +1,16 @@
-__version__ = "1.3.0"
+# -*- coding: utf-8 -*-
+
+"""Graphical statistics for Modoboa."""
+
+from __future__ import unicode_literals
+
+from pkg_resources import get_distribution, DistributionNotFound
+
+
+try:
+    __version__ = get_distribution(__name__).version
+except DistributionNotFound:
+    # package is not installed
+    pass
 
 default_app_config = "modoboa_stats.apps.StatsConfig"

--- a/modoboa_stats/forms.py
+++ b/modoboa_stats/forms.py
@@ -2,12 +2,11 @@
 
 import rrdtool
 
+from pkg_resources import parse_version
+
 from django.conf import settings
 from django.utils.translation import ugettext_lazy
 from django import forms
-
-from versionfield.constants import DEFAULT_NUMBER_BITS
-from versionfield.version import Version
 
 from modoboa.lib import form_utils
 from modoboa.parameters import forms as param_forms
@@ -45,8 +44,8 @@ class ParametersForm(param_forms.AdminParametersForm):
     def __init__(self, *args, **kwargs):
         """Check RRDtool version."""
         super(ParametersForm, self).__init__(*args, **kwargs)
-        rrd_version = Version(rrdtool.lib_version(), DEFAULT_NUMBER_BITS)
-        required_version = Version("1.6.0", DEFAULT_NUMBER_BITS)
+        rrd_version = parse_version(rrdtool.lib_version())
+        required_version = parse_version("1.6.0")
         test_mode = getattr(settings, "RRDTOOL_TEST_MODE", False)
         if rrd_version < required_version and not test_mode:
             del self.fields["greylist"]

--- a/modoboa_stats/management/commands/logparser.py
+++ b/modoboa_stats/management/commands/logparser.py
@@ -20,6 +20,7 @@ Predefined events are:
 
 from __future__ import print_function
 
+import io
 import os
 import re
 import string
@@ -53,7 +54,7 @@ class LogParser(object):
         self.debug = options["debug"]
         self.verbose = options["verbose"]
         try:
-            self.f = open(self.logfile)
+            self.f = io.open(self.logfile, encoding="utf-8")
         except IOError as errno:
             self._dprint("%s" % errno)
             sys.exit(1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-modoboa>=1.7.0
+modoboa>=1.10.0
 lxml
 rrdtool>=0.1.11

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,5 @@
+[bdist_wheel]
+universal = 1
 [pep8]
 max-line-length = 80
 exclude = migrations

--- a/setup.py
+++ b/setup.py
@@ -1,80 +1,71 @@
-"""Setup script for modoboa-admin."""
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
-import re
-import os
+"""
+A setuptools based setup module.
+
+See:
+https://packaging.python.org/en/latest/distributing.html
+"""
+
+from __future__ import unicode_literals
+
+import io
+from os import path
+from pip.req import parse_requirements
 from setuptools import setup, find_packages
 
-from modoboa_stats import __version__
 
-ROOT = os.path.dirname(__file__)
-
-
-PIP_REQUIRES = os.path.join(ROOT, "requirements.txt")
-
-
-def parse_requirements(*filenames):
-    """
-    We generate our install_requires from the pip-requires and test-requires
-    files so that we don't have to maintain the dependency definitions in
-    two places.
-    """
+def get_requirements(requirements_file):
+    """Use pip to parse requirements file."""
     requirements = []
-    for f in filenames:
-        for line in open(f, 'r').read().split('\n'):
-            # Comment lines. Skip.
-            if re.match(r'(\s*#)|(\s*$)', line):
-                continue
-            # Editable matches. Put the egg name into our reqs list.
-            if re.match(r'\s*-e\s+', line):
-                pkg = re.sub(r'\s*-e\s+.*#egg=(.*)$', r'\1', line)
-                requirements.append("%s" % pkg)
-            # File-based installs not supported/needed. Skip.
-            elif re.match(r'\s*-f\s+', line):
-                pass
-            else:
-                requirements.append(line)
+    if path.isfile(requirements_file):
+        for req in parse_requirements(requirements_file, session="hack"):
+            # check markers, such as
+            #
+            #     rope_py3k    ; python_version >= '3.0'
+            #
+            if req.match_markers():
+                requirements.append(str(req.req))
     return requirements
 
 
-def parse_dependency_links(*filenames):
-    """
-    We generate our dependency_links from the pip-requires and test-requires
-    files for the dependencies pulled from github (prepended with -e).
-    """
-    dependency_links = []
-    for f in filenames:
-        for line in open(f, 'r').read().split('\n'):
-            if re.match(r'\s*-[ef]\s+', line):
-                line = re.sub(r'\s*-[ef]\s+', '', line)
-                line = re.sub(r'\s*git\+https', 'http', line)
-                line = re.sub(r'\.git#', '/tarball/master#', line)
-                dependency_links.append(line)
-    return dependency_links
+if __name__ == "__main__":
+    HERE = path.abspath(path.dirname(__file__))
+    INSTALL_REQUIRES = get_requirements(path.join(HERE, "requirements.txt"))
 
+    with io.open(path.join(HERE, "README.rst"), encoding="utf-8") as readme:
+        LONG_DESCRIPTION = readme.read()
 
-def read(fname):
-    """A simple function to read the content of a file."""
-    return open(os.path.join(ROOT, fname)).read()
-
-
-setup(
-    name="modoboa-stats",
-    version=__version__,
-    url='http://modoboa.org/',
-    license='MIT',
-    description="Graphical statistics for Modoboa",
-    long_description=read('README.rst'),
-    author='Antoine Nguyen',
-    author_email='tonio@ngyn.org',
-    packages=find_packages(),
-    include_package_data=True,
-    install_requires=parse_requirements(PIP_REQUIRES),
-    dependency_links=parse_dependency_links(PIP_REQUIRES),
-    classifiers=['Development Status :: 5 - Production/Stable',
-                 'Framework :: Django',
-                 'Intended Audience :: System Administrators',
-                 'License :: OSI Approved :: MIT License',
-                 'Operating System :: OS Independent',
-                 'Programming Language :: Python',
-                 'Topic :: Internet :: WWW/HTTP']
-)
+    setup(
+        name="modoboa-stats",
+        description="Graphical statistics for Modoboa",
+        long_description=LONG_DESCRIPTION,
+        license="MIT",
+        url="http://modoboa.org/",
+        author="Antoine Nguyen",
+        author_email="tonio@ngyn.org",
+        classifiers=[
+            "Development Status :: 5 - Production/Stable",
+            "Environment :: Web Environment",
+            "Framework :: Django :: 1.11",
+            "Intended Audience :: System Administrators",
+            "License :: OSI Approved :: MIT License",
+            "Operating System :: OS Independent",
+            "Programming Language :: Python :: 2",
+            "Programming Language :: Python :: 2.7",
+            "Programming Language :: Python :: 3",
+            "Programming Language :: Python :: 3.4",
+            "Programming Language :: Python :: 3.5",
+            "Programming Language :: Python :: 3.6",
+            "Topic :: Communications :: Email",
+            "Topic :: Internet :: WWW/HTTP",
+        ],
+        keywords="email",
+        packages=find_packages(exclude=["docs", "test_project"]),
+        include_package_data=True,
+        zip_safe=False,
+        install_requires=INSTALL_REQUIRES,
+        use_scm_version=True,
+        setup_requires=["setuptools_scm"],
+    )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,4 @@
 factory-boy>=2.4
 testfixtures==4.7.0
+psycopg2>=2.5.4
+mysqlclient>=1.3.3


### PR DESCRIPTION
Builds will currently fail until Modoboa 1.10.0 is tagged, [this build](https://travis-ci.org/fyfe/modoboa-stats/builds/333019689) shows the other changes don't break anything. 

- refactor setup.py
    - use setuptools_scm to generate version number, normal releases will use the tagged version (ie 1.9.1), versions installed from source will append the git commit number to the version number (ie 1.9.1.dev61+g4584c93)

    - use io.open() to read text files to correctly handle utf-8 characters

    - use pip to parse requirements.txt

    - update classifiers to specify python and django versions supported

    - wheel distributions can now be built using `python setup.py bdist_wheel`

- fix travis setup
    - target oldest currently supported database servers, travis currently defaults to PostgreSQL 9.2 which isn't supported anymore.

    - move database dependencies out of travis.yml into test_requirements.txt and pin to minimum versions recommended by django.
      See https://docs.djangoproject.com/en/1.11/ref/databases/

    - remove unnecessary database setup.
      See modoboa/modoboa#1340

    - create binary wheels when a tag is pushed

- don't silence pip in Travis builds, it can provide useful information when you break something

- modoboa/modoboa#1353 remove the dependency on django-versionfield, use setuptools.parse_version instead

- python 2 fix, use io.open() to open log file using utf-8 encoding